### PR TITLE
Adds "demoURL" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "highlightjs"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "https://huafu.github.io/ember-marked/"
   }
 }


### PR DESCRIPTION
Sites likes emberaddons.com and emberobserver.com will display a link to "demoURL".
